### PR TITLE
Fix for buttonColor

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ module.exports = postcss.plugin('postcss-high-contrast', function (opts) {
 				}
 
 				if (decl.parent && propInArray(opts.buttonSelector, decl.parent.selector)) {
-					decl.value = opts.linkColor;
+					decl.value = opts.buttonColor;
 				}
 
 				// Text Color


### PR DESCRIPTION
I believe on line 117 it should be buttonColor and not linkColor. I was running the script and all my buttons were being set to link color rather than buttonColor. This change fixed that issue.