### PR TITLE
Stopped linkHoverBgColor from being removed by backgroundColor

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = postcss.plugin('postcss-high-contrast', function (opts) {
 					decl.value = decl.value.replace(pattern, opts.buttonBackgroundColor);
 				}
 
-				if (pattern.test(decl.value) && !propInArray(opts.buttonSelector, decl.parent.selector)) {
+				if (pattern.test(decl.value) && !propInArray(opts.buttonSelector, decl.parent.selector) && !propInArray(['a:hover'], decl.parent.selector)) {
 					decl.value = decl.value.replace(pattern, opts.backgroundColor);
 				}
 			}


### PR DESCRIPTION
If you set opts.linkHoverBgColor it was being overwritten by the opts.backgroundColor value.